### PR TITLE
Adding support for server names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,10 @@ ENV ALFRESCO_VERSION=enterprise \
     CA_CERT_DNAME="/C=GB/ST=UK/L=Maidenhead/O=Alfresco Software Ltd./OU=Unknown/CN=Custom Alfresco CA" \
     REPO_CERT_DNAME="/C=GB/ST=UK/L=Maidenhead/O=Alfresco Software Ltd./OU=Unknown/CN=Custom Alfresco Repository" \
     SOLR_CERT_DNAME="/C=GB/ST=UK/L=Maidenhead/O=Alfresco Software Ltd./OU=Unknown/CN=Custom Alfresco Repository Client" \
-    BROWSER_CERT_DNAME="/C=GB/ST=UK/L=Maidenhead/O=Alfresco Software Ltd./OU=Unknown/CN=Custom Browser Client"
+    BROWSER_CERT_DNAME="/C=GB/ST=UK/L=Maidenhead/O=Alfresco Software Ltd./OU=Unknown/CN=Custom Browser Client" \
+    CA_SERVER_NAME=localhost \
+    ALFRESCO_SERVER_NAME=localhost \
+    SOLR_SERVER_NAME=localhost
 
 # Exposing working folders:
 # - keystores folder, where generated keystores, truststores and password files are produced
@@ -52,4 +55,7 @@ CMD ["sh", "-c", "./run.sh \
 -repocertdname \"$REPO_CERT_DNAME\" \
 -solrcertdname \"$SOLR_CERT_DNAME\" \
 -browsercertdname \"$BROWSER_CERT_DNAME\" \
+-caservername \"$CA_SERVER_NAME\" \
+-alfrescoservername \"$ALFRESCO_SERVER_NAME\" \
+-solrservername \"$SOLR_SERVER_NAME\" \
 "]

--- a/README.md
+++ b/README.md
@@ -104,7 +104,11 @@ Both command line scripts and Docker Image resources can be parametrised by usin
 | -repocertdname        | REPO_CERT_DNAME       | Distinguished Name of the Repository certificate, starting with slash and quoted | "/C=GB/ST=UK/L=Maidenhead/O=Alfresco Software Ltd./OU=Unknown/CN=Custom Alfresco Repository" |
 | -solrcertdname        | SOLR_CERT_DNAME       | Distinguished Name of the SOLR certificate, starting with slash and quoted | "/C=GB/ST=UK/L=Maidenhead/O=Alfresco Software Ltd./OU=Unknown/CN=Custom Alfresco Repository Client" |
 | -browsercertdname     | BROWSER_CERT_DNAME       | Distinguished Name of the BROWSER certificate, starting with slash and quoted | "/C=GB/ST=UK/L=Maidenhead/O=Alfresco Software Ltd./OU=Unknown/CN=Custom Browser Client" |
+| -caservername         | CA_SERVER_NAME        | DNS Name for CA Server       | Any string, `localhost` by default        |
+| -alfrescoservername   | ALFRESCO_SERVER_NAME  | DNS Name for Alfresco Server | Any string, `localhost` by default        |
+| -solrservername       | SOLR_SERVER_NAME      | DNS Name for SOLR Server     | Any string, `localhost` by default        |
 
+When using Alfresco on an internal network, each server should have a different name. This names can be configured on the parameters named as `*servername`. In order to avoid browser complains about certificates, it's recommended to include the name of the server as `Alternative Name` in the certificate. This should be at least required for SOLR Web Console, as this application is only available in `https` when using this configuration. If you are working under a Web Proxy, use the name of this proxy for the `*servername` parameters.
 
 ## Bash Shell Script Standalone (Linux, Mac OS X)
 

--- a/ssl-tool-win/run.cmd
+++ b/ssl-tool-win/run.cmd
@@ -50,6 +50,11 @@ SET SOLR_CLIENT_CERT_DNAME=/C=GB/ST=UK/L=Maidenhead/O=Alfresco Software Ltd./OU=
 REM Distinguished name of the Browser Certificate for SOLR
 SET BROWSER_CLIENT_CERT_DNAME=/C=GB/ST=UK/L=Maidenhead/O=Alfresco Software Ltd./OU=Unknown/CN=Custom Browser Client
 
+REM Alfresco and SOLR server names, to be used as Alternative Name in the certificates
+SET CA_SERVER_NAME=localhost
+SET ALFRESCO_SERVER_NAME=localhost
+SET SOLR_SERVER_NAME=localhost
+
 REM RSA key length (1024, 2048, 4096)
 SET KEY_SIZE=1024
 
@@ -144,6 +149,24 @@ IF NOT "%1"=="" (
     SHIFT
     GOTO loop
   )
+  IF "%1"=="-caservername" (
+    SHIFT
+    SET CA_SERVER_NAME=%~2
+    SHIFT
+    GOTO loop
+  )
+  IF "%1"=="-alfrescoservername" (
+    SHIFT
+    SET ALFRESCO_SERVER_NAME=%~2
+    SHIFT
+    GOTO loop
+  )
+  IF "%1"=="-solrservername" (
+    SHIFT
+    SET SOLR_SERVER_NAME=%~2
+    SHIFT
+    GOTO loop
+  )
   ECHO "An invalid parameter was received: %1"
   EXIT /b
 )
@@ -221,6 +244,8 @@ ECHO 1000 > ca\serial
 
 openssl genrsa -aes256 -passout pass:%KEYSTORE_PASS% -out ca\private\ca.key.pem %KEY_SIZE%
 
+powershell -Command "(gc -Encoding utf8 openssl.cnf) -replace '(^DNS.*\.).*', 'DNS.1=%CA_SERVER_NAME%' | Out-File -Encoding utf8 openssl.cnf"
+powershell -Command "(gc -Encoding utf8 openssl.cnf) | Foreach-Object {$_ -replace '\xEF\xBB\xBF', ''} | Set-Content openssl.cnf"
 openssl req -config openssl.cnf ^
       -key ca\private\ca.key.pem ^
       -new -x509 -days 7300 -sha256 -extensions v3_ca ^
@@ -229,6 +254,8 @@ openssl req -config openssl.cnf ^
       -passin pass:%KEYSTORE_PASS%
 
 REM Generate Server Certificate for Alfresco (issued by just generated CA)
+powershell -Command "(gc -Encoding utf8 openssl.cnf) -replace '(^DNS.*\.).*', 'DNS.1=%ALFRESCO_SERVER_NAME%' | Out-File -Encoding utf8 openssl.cnf"
+powershell -Command "(gc -Encoding utf8 openssl.cnf) | Foreach-Object {$_ -replace '\xEF\xBB\xBF', ''} | Set-Content openssl.cnf"
 openssl req -newkey rsa:%KEY_SIZE% -nodes -out %CERTIFICATES_DIR%\repository.csr ^
 -keyout %CERTIFICATES_DIR%\repository.key -subj "%REPO_CERT_DNAME%"
 
@@ -239,6 +266,8 @@ openssl pkcs12 -export -out %CERTIFICATES_DIR%/repository.p12 -inkey %CERTIFICAT
 -in %CERTIFICATES_DIR%\repository.cer -password pass:%KEYSTORE_PASS% -certfile ca\certs\ca.cert.pem
 
 REM Server Certificate for SOLR (issued by just generated CA)
+powershell -Command "(gc -Encoding utf8 openssl.cnf) -replace '(^DNS.*\.).*', 'DNS.1=%SOLR_SERVER_NAME%' | Out-File -Encoding utf8 openssl.cnf"
+powershell -Command "(gc -Encoding utf8 openssl.cnf) | Foreach-Object {$_ -replace '\xEF\xBB\xBF', ''} | Set-Content openssl.cnf"
 openssl req -newkey rsa:%KEY_SIZE% -nodes -out %CERTIFICATES_DIR%\solr.csr ^
 -keyout %CERTIFICATES_DIR%\solr.key -subj "%SOLR_CLIENT_CERT_DNAME%"
 


### PR DESCRIPTION
Providing a server name to be used as Alternative Name in the certificate. Relevant for SOLR, as Web Console is accessed using a browser.