### PR TITLE
Add client/clientAuth types to repo/solr certs and fix cert regeneration

### DIFF
--- a/ssl-tool-win/openssl.cnf
+++ b/ssl-tool-win/openssl.cnf
@@ -90,6 +90,17 @@ keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
 subjectAltName = @alt_names
 
+[ clientServer_cert ]
+# Extensions for client/server certificates (`man x509v3_config`).
+basicConstraints = CA:FALSE
+nsCertType = server, client
+nsComment = "OpenSSL Generated Client/Server Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer:always
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = @alt_names
+
 [ client_cert ]
 basicConstraints = CA:FALSE
 nsCertType = client

--- a/ssl-tool-win/openssl.cnf
+++ b/ssl-tool-win/openssl.cnf
@@ -79,17 +79,6 @@ authorityKeyIdentifier = keyid:always,issuer
 basicConstraints = CA:true
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
 
-[ server_cert ]
-# Extensions for server certificates (`man x509v3_config`).
-basicConstraints = CA:FALSE
-nsCertType = server
-nsComment = "OpenSSL Generated Server Certificate"
-subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid,issuer:always
-keyUsage = critical, digitalSignature, keyEncipherment
-extendedKeyUsage = serverAuth
-subjectAltName = @alt_names
-
 [ clientServer_cert ]
 # Extensions for client/server certificates (`man x509v3_config`).
 basicConstraints = CA:FALSE

--- a/ssl-tool-win/run.cmd
+++ b/ssl-tool-win/run.cmd
@@ -296,7 +296,7 @@ powershell -Command "(gc -Encoding utf8 openssl.cnf) | Foreach-Object {$_ -repla
 openssl req -newkey rsa:%KEY_SIZE% -nodes -out %CERTIFICATES_DIR%\repository.csr ^
 -keyout %CERTIFICATES_DIR%\repository.key -subj "%REPO_CERT_DNAME%"
 
-openssl ca -config openssl.cnf -extensions server_cert -passin pass:%KEYSTORE_PASS% -batch -notext ^
+openssl ca -config openssl.cnf -extensions clientServer_cert -passin pass:%KEYSTORE_PASS% -batch -notext ^
 -in %CERTIFICATES_DIR%\repository.csr -out %CERTIFICATES_DIR%\repository.cer
 
 openssl pkcs12 -export -out %CERTIFICATES_DIR%/repository.p12 -inkey %CERTIFICATES_DIR%\repository.key ^
@@ -308,7 +308,7 @@ powershell -Command "(gc -Encoding utf8 openssl.cnf) | Foreach-Object {$_ -repla
 openssl req -newkey rsa:%KEY_SIZE% -nodes -out %CERTIFICATES_DIR%\solr.csr ^
 -keyout %CERTIFICATES_DIR%\solr.key -subj "%SOLR_CLIENT_CERT_DNAME%"
 
-openssl ca -config openssl.cnf -extensions server_cert -passin pass:%KEYSTORE_PASS% -batch -notext ^
+openssl ca -config openssl.cnf -extensions clientServer_cert -passin pass:%KEYSTORE_PASS% -batch -notext ^
 -in %CERTIFICATES_DIR%\solr.csr -out %CERTIFICATES_DIR%\solr.cer
 
 openssl pkcs12 -export -out %CERTIFICATES_DIR%\solr.p12 -inkey %CERTIFICATES_DIR%\solr.key ^

--- a/ssl-tool/openssl.cnf
+++ b/ssl-tool/openssl.cnf
@@ -90,6 +90,17 @@ keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
 subjectAltName = @alt_names
 
+[ clientServer_cert ]
+# Extensions for client/server certificates (`man x509v3_config`).
+basicConstraints = CA:FALSE
+nsCertType = server, client
+nsComment = "OpenSSL Generated Client/Server Certificate"
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer:always
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = @alt_names
+
 [ client_cert ]
 basicConstraints = CA:FALSE
 nsCertType = client

--- a/ssl-tool/openssl.cnf
+++ b/ssl-tool/openssl.cnf
@@ -79,17 +79,6 @@ authorityKeyIdentifier = keyid:always,issuer
 basicConstraints = CA:true
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
 
-[ server_cert ]
-# Extensions for server certificates (`man x509v3_config`).
-basicConstraints = CA:FALSE
-nsCertType = server
-nsComment = "OpenSSL Generated Server Certificate"
-subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid,issuer:always
-keyUsage = critical, digitalSignature, keyEncipherment
-extendedKeyUsage = serverAuth
-subjectAltName = @alt_names
-
 [ clientServer_cert ]
 # Extensions for client/server certificates (`man x509v3_config`).
 basicConstraints = CA:FALSE

--- a/ssl-tool/run.sh
+++ b/ssl-tool/run.sh
@@ -126,52 +126,47 @@ function generate {
 
   # Remove previous working directories and certificates
   if [ -d ca ]; then
-      rm -rf ca
-  fi
-
-  if [ -d $CERTIFICATES_DIR ]; then
-      rm -rf $CERTIFICATES_DIR
+      rm -rf ca/*
   fi
 
   # Create folders for truststores, keystores and certificates
   if [ ! -d "$KEYSTORES_DIR" ]; then
-    mkdir $KEYSTORES_DIR
+    mkdir -p $KEYSTORES_DIR
   else
-    rm -rf $KEYSTORES_DIR
+    rm -rf $KEYSTORES_DIR/*
   fi
 
   if [ ! -d "$ALFRESCO_KEYSTORES_DIR" ]; then
-    mkdir $ALFRESCO_KEYSTORES_DIR
+    mkdir -p $ALFRESCO_KEYSTORES_DIR
   else
-    rm -rf $ALFRESCO_KEYSTORES_DIR
+    rm -rf $ALFRESCO_KEYSTORES_DIR/*
   fi
 
   if [ ! -d "$SOLR_KEYSTORES_DIR" ]; then
-    mkdir $SOLR_KEYSTORES_DIR
+    mkdir -p $SOLR_KEYSTORES_DIR
   else
-    rm -rf $SOLR_KEYSTORES_DIR
+    rm -rf $SOLR_KEYSTORES_DIR/*
   fi
 
   if [ "$ALFRESCO_VERSION" = "enterprise" ]; then
     if [ ! -d "$ZEPPELIN_KEYSTORES_DIR" ]; then
-      mkdir $ZEPPELIN_KEYSTORES_DIR
+      mkdir -p $ZEPPELIN_KEYSTORES_DIR
     else
-      rm -rf $ZEPPELIN_KEYSTORES_DIR
+      rm -rf $ZEPPELIN_KEYSTORES_DIR/*
     fi
   fi
 
   if [ ! -d "$CLIENT_KEYSTORES_DIR" ]; then
-    mkdir $CLIENT_KEYSTORES_DIR
+    mkdir -p $CLIENT_KEYSTORES_DIR
   else
-    rm -rf $CLIENT_KEYSTORES_DIR
+    rm -rf $CLIENT_KEYSTORES_DIR/*
   fi
 
   if [ ! -d "$CERTIFICATES_DIR" ]; then
-    mkdir $CERTIFICATES_DIR
+    mkdir -p $CERTIFICATES_DIR
   else
-    rm -rf $CERTIFICATES_DIR
+    rm -rf $CERTIFICATES_DIR/*
   fi
-
 
   #
   # CA
@@ -212,7 +207,7 @@ function generate {
   fi
   openssl req -newkey rsa:$KEY_SIZE -nodes -out $CERTIFICATES_DIR/repository.csr -keyout $CERTIFICATES_DIR/repository.key -subj "$REPO_CERT_DNAME"
 
-  openssl ca -config openssl.cnf -extensions server_cert -passin pass:$KEYSTORE_PASS -batch -notext \
+  openssl ca -config openssl.cnf -extensions clientServer_cert -passin pass:$KEYSTORE_PASS -batch -notext \
   -in $CERTIFICATES_DIR/repository.csr -out $CERTIFICATES_DIR/repository.cer
 
   openssl pkcs12 -export -out $CERTIFICATES_DIR/repository.p12 -inkey $CERTIFICATES_DIR/repository.key \
@@ -226,7 +221,7 @@ function generate {
   fi
   openssl req -newkey rsa:$KEY_SIZE -nodes -out $CERTIFICATES_DIR/solr.csr -keyout $CERTIFICATES_DIR/solr.key -subj "$SOLR_CLIENT_CERT_DNAME"
 
-  openssl ca -config openssl.cnf -extensions server_cert -passin pass:$KEYSTORE_PASS -batch -notext \
+  openssl ca -config openssl.cnf -extensions clientServer_cert -passin pass:$KEYSTORE_PASS -batch -notext \
   -in $CERTIFICATES_DIR/solr.csr -out $CERTIFICATES_DIR/solr.cer
 
   openssl pkcs12 -export -out $CERTIFICATES_DIR/solr.p12 -inkey $CERTIFICATES_DIR/solr.key \


### PR DESCRIPTION
Currently, both the Repository and SOLR certificates are generated as server-only certificates, despite them being used for mTLS in the ACS - ASS integration. Well behaving TLS clients may refuse to use the certificates when calling TLS protected APIs. This so happened to me in a current client's environment after updating OpenSSL to version `1.1.1k FIPS 25 Mar 2021`. Both the SOLR internal HTTP client as well as `cUrl` reported `unsupported_certificate` when calling the ACS SOLR APIs. Only by adding the necessary type + key usage extension to the certificates could this problem be fixed.

This PR adds the `clientServer_cert` configuration for certificates and uses it for Repository and SOLR certificates.
This PR also aligns the bash script folder cleanup logic when certificates are regenerated with the Windows command, only deleting the contents of existing folders not the folders itself. Additionally, the folder creation logic now supports transitive folder creation in case any folders on the path are non-existent, reducing potential errors.