### PR TITLE
edit Dockerfile to add symlink to keytool in /usr/local/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN yum -y update && \
     yum -y install openssl openssl-devel && \
     yum clean all
 
+# Put keytool in the path
+RUN ln -s /usr/lib/jvm/jre/bin/keytool /usr/local/bin
+
 # Copy OpenSSL configuration and generator script
 COPY ["ssl-tool/openssl.cnf", "ssl-tool/run.sh", "./"]
 


### PR DESCRIPTION
I tried to use this tool to generate certs, but got an error that keytool was not in the path.

This patch seems to have fixed the problem.