### PR TITLE
fix run.sh when calling './run.sh -alfrescoversion community'

### DIFF
--- a/ssl-tool/run.sh
+++ b/ssl-tool/run.sh
@@ -356,8 +356,10 @@ function generate {
     rm ${ALFRESCO_KEYSTORES_DIR}/keystore-passwords.properties
     mv ${SOLR_KEYSTORES_DIR}/ssl.repo.client.truststore ${SOLR_KEYSTORES_DIR}/ssl-repo-client.truststore
     mv ${SOLR_KEYSTORES_DIR}/ssl.repo.client.keystore ${SOLR_KEYSTORES_DIR}/ssl-repo-client.keystore
-    mv ${ZEPPELIN_KEYSTORES_DIR}/ssl.repo.client.keystore ${ZEPPELIN_KEYSTORES_DIR}/ssl-repo-client.keystore
-    mv ${ZEPPELIN_KEYSTORES_DIR}/ssl.repo.client.truststore ${ZEPPELIN_KEYSTORES_DIR}/ssl-repo-client.truststore
+    if [ "$ALFRESCO_VERSION" = "enterprise" ]; then
+      mv ${ZEPPELIN_KEYSTORES_DIR}/ssl.repo.client.keystore ${ZEPPELIN_KEYSTORES_DIR}/ssl-repo-client.keystore
+      mv ${ZEPPELIN_KEYSTORES_DIR}/ssl.repo.client.truststore ${ZEPPELIN_KEYSTORES_DIR}/ssl-repo-client.truststore
+    fi
   fi
 
 }


### PR DESCRIPTION
This should fix the error:
```
mv: cannot stat 'keystores/zeppelin/ssl.repo.client.keystore': No such file or directory
```