### PR TITLE
ACS-8197 Disable services that are not exposed via nginx

### DIFF
--- a/docker-compose/enterprise/docker-compose.yml
+++ b/docker-compose/enterprise/docker-compose.yml
@@ -241,6 +241,10 @@ services:
     proxy:
         image: alfresco/alfresco-acs-nginx:${ACS_NGINX_TAG}
         mem_limit: 128m
+        environment:
+          DISABLE_CONTROL_CENTER: true
+          DISABLE_SYNCSERVICE: true
+          DISABLE_PROMETHEUS: true
         depends_on:
             - alfresco
             - digital-workspace

--- a/docker-compose/enterprise/docker-compose.yml
+++ b/docker-compose/enterprise/docker-compose.yml
@@ -242,9 +242,9 @@ services:
         image: alfresco/alfresco-acs-nginx:${ACS_NGINX_TAG}
         mem_limit: 128m
         environment:
-          DISABLE_CONTROL_CENTER: true
-          DISABLE_SYNCSERVICE: true
-          DISABLE_PROMETHEUS: true
+            DISABLE_CONTROL_CENTER: true
+            DISABLE_SYNCSERVICE: true
+            DISABLE_PROMETHEUS: true
         depends_on:
             - alfresco
             - digital-workspace


### PR DESCRIPTION
Minor improvement, config fix for Nginx since we're not exposing these services and they're enabled by default.