### PR TITLE
ACS-8197 Quote booleans in docker-compose

### DIFF
--- a/docker-compose/enterprise/docker-compose.yml
+++ b/docker-compose/enterprise/docker-compose.yml
@@ -242,9 +242,9 @@ services:
         image: alfresco/alfresco-acs-nginx:${ACS_NGINX_TAG}
         mem_limit: 128m
         environment:
-            DISABLE_CONTROL_CENTER: true
-            DISABLE_SYNCSERVICE: true
-            DISABLE_PROMETHEUS: true
+            DISABLE_CONTROL_CENTER: "true"
+            DISABLE_SYNCSERVICE: "true"
+            DISABLE_PROMETHEUS: "true"
         depends_on:
             - alfresco
             - digital-workspace


### PR DESCRIPTION
One last configuration fix as I noticed some specific `docker-compose` V1 (older) versions prefer booleans to be quoted and may whine about it otherwise _(e.g.: `The Compose file 'docker-compose.yml' is invalid because:
services.proxy.environment.DISABLE_CONTROL_CENTER contains true, which is an invalid type, it should be a string, number, or a null
Error: Process completed with exit code 1.`)_